### PR TITLE
Add pushing the latest build artifacts on a `dist` branch

### DIFF
--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -1,0 +1,31 @@
+name: Build
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint-test-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Node & NPM
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build header
+        run: npm run build
+
+      - name: Publish web component to dist branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist/assets
+          publish_branch: dist

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
   build: {
     rollupOptions: {
       output: {
-        entryFileNames: `assets/_header.js`,
+        entryFileNames: `assets/header.js`,
       },
     },
   },


### PR DESCRIPTION
This will be used in conjunction with [Jsdelivr](https://www.jsdelivr.com/) to be able to fetch the JS file with the following url:

https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js