### PR TITLE
Read user details from /whoami

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The geOrchestra header is built using Vue and published as a web component called `geor-header`.
 
+## Requirements
+
+The `geor-header` component currently requires the [georchestra-gateway](https://github.com/georchestra/georchestra-gateway). It will **not** work with the default security proxy.
+
 ## Usage
 
 The web component is distributed as a static JS file on the `dist` branch of this repository. It can easily be accessed using a service such as JsDelivr with the following url:

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,4 @@
 import { fileURLToPath, URL } from 'node:url'
-
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
@@ -15,6 +14,16 @@ export default defineConfig({
     rollupOptions: {
       output: {
         entryFileNames: `assets/header.js`,
+      },
+    },
+  },
+  server: {
+    proxy: {
+      '^/(whoami|login|logout)': {
+        // FIXME: replace this with demo.georchestra.org when it uses the gateway
+        target:
+          'https://gateway.mel.integration.apps.gs-fr-prod.camptocamp.com',
+        changeOrigin: true,
       },
     },
   },


### PR DESCRIPTION
This PR makes the header actually functional by:
* reading the current user info (name and roles) from the `/whoami` endpoint
* adding a proxy in dev mode pointing to https://gateway.mel.integration.apps.gs-fr-prod.camptocamp.com in order to test things

Note that the header could theoretically work with the security proxy but there's just one thing missing: a `/login` route (currently the login is done on `/cas/login`). **So for now this only works on a platform using the gateway**.

@fgravin I've reworked the parsing of the admin roles a little bit to make it more concise, please let me know if you think that's appropriate, thanks!