### PR TITLE
feat: add legacy option to display iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ To include it in an existing application:
 
 Note: unlike with iframes there is no need to specify a height, the component will decide of its own size and "push" the content around accordingly.
 
-Iframe can still be set with defining `legacy_url` attribute, style can also be set with `legacy_style` attribute :
+Iframe can still be set with defining `legacy-url` attribute, style can also be set with `legacy-style` attribute :
   ```html
-  <geor-header legacy_url="myheader.com" legacy_style="width: 100%"></geor-header>
+  <geor-header legacy-url="myheader.com" legacy-style="width: 100%"></geor-header>
   ```
  
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ To include it in an existing application:
 
 Note: unlike with iframes there is no need to specify a height, the component will decide of its own size and "push" the content around accordingly.
 
+Iframe can still be set with defining `legacy_url` attribute, style can also be set with `legacy_style` attribute :
+  ```html
+  <geor-header legacy_url="myheader.com" legacy_style="width: 100%"></geor-header>
+  ```
+ 
+
 ## Development
 
 On every new commit on main the `header.js` file on the `dist` branch is updated automatically.

--- a/src/header.ce.vue
+++ b/src/header.ce.vue
@@ -7,6 +7,9 @@ import UserIcon from './ui/UserIcon.vue'
 const props = defineProps<{
   lang?: string
   activeApp?: string
+  //legacy option : using old iframe option
+  legacy_url?: string
+  legacy_style?: string
 }>()
 
 const state = reactive({
@@ -31,7 +34,13 @@ onMounted(() => {
 })
 </script>
 <template>
-  <header class="host">
+  <div v-if="props.legacy_url">
+    <iframe
+      v-bind:src="props.legacy_url"
+      v-bind:style="props.legacy_style"
+    ></iframe>
+  </div>
+  <header v-if="!props.legacy_url" class="host">
     <div
       class="admin pr-8 items-center bg-primary/20 text-secondary/80 flex justify-end gap-5 text-sm font-sans"
       v-if="isAdmin"

--- a/src/header.ce.vue
+++ b/src/header.ce.vue
@@ -8,8 +8,8 @@ const props = defineProps<{
   lang?: string
   activeApp?: string
   //legacy option : using old iframe option
-  legacy_url?: string
-  legacy_style?: string
+  legacyUrl?: string
+  legacyStyle?: string
 }>()
 
 const state = reactive({
@@ -34,13 +34,13 @@ onMounted(() => {
 })
 </script>
 <template>
-  <div v-if="props.legacy_url">
+  <div v-if="props.legacyUrl">
     <iframe
-      v-bind:src="props.legacy_url"
-      v-bind:style="props.legacy_style"
+      v-bind:src="props.legacyUrl"
+      v-bind:style="props.legacyStyle"
     ></iframe>
   </div>
-  <header v-if="!props.legacy_url" class="host">
+  <header v-if="!props.legacyUrl" class="host">
     <div
       class="admin pr-8 items-center bg-primary/20 text-secondary/80 flex justify-end gap-5 text-sm font-sans"
       v-if="isAdmin"


### PR DESCRIPTION
This PR adds a legacy option to the the component. 

If a `legacy_url` is set, it uses the old iframe strategy.