### PR TITLE
Set header colors themable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ header {
   }
 ```
 
+Note: It's important to target the `header` tag here to override the css variables, because of the shadow DOM. 
+
 ## Development
 
 On every new commit on main the `header.js` file on the `dist` branch is updated automatically.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ Attributes available :
 | style         | adds this style to iframe or host tag (if legacy url is not used)                                    | `<geor-header legacy-url="myheader.com" style="width: 100%"></geor-header>` | v        | v         |
 | stylesheet    | allow to add stylesheet for new header                                                               | `<geor-header stylesheet="myfile.css"></geor-header>`   | v        |           |
  
+3. Optional : Override default colors with `stylesheet` attribute : 
+
+```css
+header {
+    --georchestra-primary: #124885;
+    --georchestra-secondary: #83532b;
+    --georchestra-primary-light: #12488540;
+    --georchestra-secondary-light: #83532b40;
+  }
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,15 @@ Iframe can still be set with defining `legacy-url` attribute, style can also be 
 
 Attributes available :
 
-| Attribute     | Description                                                                                          | Example                                                                     | For host | For legacy |
-|---------------|------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|----------|------------|
-| lang          | Used to force header language (default value : en)                                                   | `<geor-header lang='de'>`                                                   | v        |            |
-| active-app    | Use this attribute to set the active class in menu                                                   | `<geor-header active-app='console'>`                                        | v        | v          |
-| logo-url      | Use this attribute to set the logo for the new header (not legacy one).                              | `<geor-header logo-url='https://linktomylogo.com'>`                         | v        |            |
-| legacy-header | Use this attribute to enable the legacy header `iframe` tag. Needs `legacy-url`.                     | `<geor-header legacy-header='true' legacy-url="/header/">`                  |          | v          |
-| legacy-url    | Legacy URL: if set, activates iframe with src attribute pointing to this URL. Needs `legacy-header`. | `<geor-header legacy-header='true' legacy-url="/header/"></geor-header>`    |          | v          |
-| style         | adds this style to iframe or host tag (if legacy url is not used)                                    | `<geor-header legacy-url="myheader.com" style="width: 100%"></geor-header>` | v        | v          |
+| Attribute     | Description                                                                                          | Example                                                                   | For host | For legacy |
+|---------------|------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|----------|-----------|
+| lang          | Used to force header language (default value : en)                                                   | `<geor-header lang='de'>`                                                 | v        |           |
+| active-app    | Use this attribute to set the active class in menu                                                   | `<geor-header active-app='console'>`                                      | v        | v         |
+| logo-url      | Use this attribute to set the logo for the new header (not legacy one).                              | `<geor-header logo-url='https://linktomylogo.com'>`                       | v        |           |
+| legacy-header | Use this attribute to enable the legacy header `iframe` tag. Needs `legacy-url`.                     | `<geor-header legacy-header='true' legacy-url="/header/">`                |          | v         |
+| legacy-url    | Legacy URL: if set, activates iframe with src attribute pointing to this URL. Needs `legacy-header`. | `<geor-header legacy-header='true' legacy-url="/header/"></geor-header>`  |          | v         |
+| style         | adds this style to iframe or host tag (if legacy url is not used)                                    | `<geor-header legacy-url="myheader.com" style="width: 100%"></geor-header>` | v        | v         |
+| stylesheet    | allow to add stylesheet for new header                                                               | `<geor-header stylesheet="myfile.css"></geor-header>`   | v        |           |
  
 
 ## Development

--- a/index.html
+++ b/index.html
@@ -11,12 +11,6 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>geOrchestra header</title>
-    <style>
-      html {
-        --primary: #85127e;
-        --secondary: #1b1f3b;
-      }
-    </style>
   </head>
   <body style="margin: 0">
     <geor-header

--- a/index.html
+++ b/index.html
@@ -11,9 +11,16 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>geOrchestra header</title>
+      <style>
+          html {
+              --primary: #85127e;
+              --secondary: #1b1f3b;
+          }
+      </style>
   </head>
   <body style="margin: 0; height: 80px">
     <geor-header logo-url="https://www.georchestra.org/public/georchestra-logo.svg" active-app="datahub"></geor-header>
     <script type="module" src="/src/main.ts"></script>
   </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -11,16 +11,18 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>geOrchestra header</title>
-      <style>
-          html {
-              --primary: #85127e;
-              --secondary: #1b1f3b;
-          }
-      </style>
+    <style>
+      html {
+        --primary: #85127e;
+        --secondary: #1b1f3b;
+      }
+    </style>
   </head>
-  <body style="margin: 0; height: 80px">
-    <geor-header logo-url="https://www.georchestra.org/public/georchestra-logo.svg" active-app="datahub"></geor-header>
+  <body style="margin: 0">
+    <geor-header
+      logo-url="https://www.georchestra.org/public/georchestra-logo.svg"
+      active-app="datahub"
+    ></geor-header>
     <script type="module" src="/src/main.ts"></script>
   </body>
-
 </html>

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -26,6 +26,7 @@ export interface User {
 }
 
 export interface AdminRoles {
+  superUser: boolean
   admin: boolean
   console: boolean
   catalog: boolean
@@ -55,6 +56,7 @@ export function getAdminRoles(roles: KNOWN_ROLES[]): AdminRoles | null {
     console || catalog || viewer || roles.indexOf('ROLE_ADMINISTRATOR') > -1
   if (!admin) return null
   return {
+    superUser,
     admin,
     console,
     catalog,

--- a/src/header.ce.vue
+++ b/src/header.ce.vue
@@ -50,7 +50,7 @@ onMounted(() => {
   getUserDetails().then(user => {
     state.user = user
 
-    if (user?.adminRoles?.admin) {
+    if (user?.adminRoles?.superUser) {
       getPlatformInfos().then(
         platformInfos => (state.platformInfos = platformInfos)
       )

--- a/src/header.ce.vue
+++ b/src/header.ce.vue
@@ -19,6 +19,7 @@ const props = defineProps<{
   legacyHeader?: string
   legacyUrl?: string
   style?: string
+  stylesheet?: string
 }>()
 
 const state = reactive({
@@ -69,11 +70,12 @@ onMounted(() => {
     ></iframe>
   </div>
   <header v-else class="host h-[80px] text-base" v-bind:style="props.style">
+    <link rel="stylesheet" :href="props.stylesheet" v-if="props.stylesheet" />
     <div class="justify-between text-slate-600 sm:flex hidden h-full bg-white">
       <div class="flex">
         <a
           href="/"
-          class="flex justify-center items-center px-8 rounded-r-lg py-2"
+          class="flex justify-center items-center px-8 rounded-r-lg py-2 bg-primary_light"
         >
           <img
             v-if="props.logoUrl"
@@ -263,6 +265,15 @@ onMounted(() => {
   </header>
 </template>
 
+<style>
+header {
+  --georchestra-primary: #85127e;
+  --georchestra-secondary: #1b1f3b;
+  --georchestra-primary-light: rgba(133, 18, 126, 0.3);
+  --georchestra-secondary-light: rgba(27, 31, 59, 0.3);
+}
+</style>
+
 <style scoped>
 @tailwind base;
 @tailwind components;
@@ -284,7 +295,7 @@ onMounted(() => {
     @apply relative text-lg w-fit block after:hover:scale-x-[82%] px-2 mx-2 hover:text-black first-letter:capitalize;
   }
   .nav-item:after {
-    @apply block content-[''] absolute h-[3px] bg-gradient-to-r from-primary to-slate-300 w-full scale-x-0  transition duration-300 origin-left;
+    @apply block content-[''] absolute h-[3px] bg-gradient-to-r from-primary to-secondary_light w-full scale-x-0  transition duration-300 origin-left;
   }
   .nav-item.active {
     @apply after:scale-x-[82%] after:bg-primary after:bg-none text-gray-900;

--- a/src/header.ce.vue
+++ b/src/header.ce.vue
@@ -73,7 +73,7 @@ onMounted(() => {
       <div class="flex">
         <a
           href="/"
-          class="flex justify-center items-center px-8 bg-primary/10 rounded-r-lg py-2"
+          class="flex justify-center items-center px-8 bg-primary rounded-r-lg py-2"
         >
           <img
             v-if="props.logoUrl"
@@ -282,31 +282,31 @@ onMounted(() => {
 
 @layer components {
   .nav-item-mobile {
-    @apply text-xl block text-center py-3 mx-2 w-full border-b border-b-secondary/10 first-letter:capitalize;
+    @apply text-xl block text-center py-3 mx-2 w-full border-b border-b-secondary first-letter:capitalize;
   }
   .nav-item {
     @apply relative text-lg w-fit block after:hover:scale-x-[82%] px-2 mx-2 hover:text-black first-letter:capitalize;
   }
   .nav-item:after {
-    @apply block content-[''] absolute h-[3px] bg-gradient-to-r from-primary to-primary/30 w-full scale-x-0  transition duration-300 origin-left;
+    @apply block content-[''] absolute h-[3px] bg-gradient-to-r from-primary to-secondary w-full scale-x-0  transition duration-300 origin-left;
   }
   .nav-item.active {
-    @apply after:scale-x-[82%] after:bg-primary text-gray-900;
+    @apply after:scale-x-[82%] after:bg-primary after:bg-none text-gray-900;
   }
   .btn {
-    @apply px-4 py-2 mx-2 text-slate-100 bg-primary rounded hover:bg-primary/70 transition-colors first-letter:capitalize;
+    @apply px-4 py-2 mx-2 text-slate-100 bg-primary rounded hover:bg-primary hover:bg-opacity-70 transition-colors first-letter:capitalize;
   }
   .link-btn {
-    @apply text-primary/60 hover:text-primary hover:underline underline-offset-8 decoration-2 decoration-primary/50 flex flex-col items-center;
+    @apply text-primary text-opacity-60 hover:text-primary hover:underline underline-offset-8 decoration-2 decoration-primary flex flex-col items-center;
   }
   .admin-dropdown > li {
-    @apply block text-center hover:bg-primary/10 text-gray-700 hover:text-black capitalize;
+    @apply block text-center hover:bg-primary hover:bg-opacity-10 text-gray-700 hover:text-black capitalize;
   }
   .admin-dropdown > li > a {
     @apply block w-full h-full py-3;
   }
   .admin-dropdown > li.active {
-    @apply bg-primary/20;
+    @apply bg-primary bg-opacity-20;
   }
   .icon-dropdown {
     @apply w-4 h-4 inline-block align-text-top;

--- a/src/header.ce.vue
+++ b/src/header.ce.vue
@@ -269,8 +269,8 @@ onMounted(() => {
 header {
   --georchestra-primary: #85127e;
   --georchestra-secondary: #1b1f3b;
-  --georchestra-primary-light: rgba(133, 18, 126, 0.3);
-  --georchestra-secondary-light: rgba(27, 31, 59, 0.3);
+  --georchestra-primary-light: #85127e1a;
+  --georchestra-secondary-light: #1b1f3b1a;
 }
 </style>
 

--- a/src/header.ce.vue
+++ b/src/header.ce.vue
@@ -75,7 +75,7 @@ onMounted(() => {
       <div class="flex">
         <a
           href="/"
-          class="flex justify-center items-center px-8 rounded-r-lg py-2 bg-primary_light"
+          class="flex justify-center items-center px-8 rounded-r-lg py-2 bg-primary-light"
         >
           <img
             v-if="props.logoUrl"
@@ -295,7 +295,7 @@ header {
     @apply relative text-lg w-fit block after:hover:scale-x-[82%] px-2 mx-2 hover:text-black first-letter:capitalize;
   }
   .nav-item:after {
-    @apply block content-[''] absolute h-[3px] bg-gradient-to-r from-primary to-secondary_light w-full scale-x-0  transition duration-300 origin-left;
+    @apply block content-[''] absolute h-[3px] bg-gradient-to-r from-primary to-secondary-light w-full scale-x-0  transition duration-300 origin-left;
   }
   .nav-item.active {
     @apply after:scale-x-[82%] after:bg-primary after:bg-none text-gray-900;
@@ -307,13 +307,13 @@ header {
     @apply text-primary hover:text-slate-700 hover:underline underline-offset-8 decoration-2 decoration-slate-700 flex flex-col items-center;
   }
   .admin-dropdown > li {
-    @apply block text-center hover:bg-primary hover:bg-slate-300 text-gray-700 hover:text-black capitalize;
+    @apply block text-center hover:bg-primary-light text-gray-700 hover:text-black capitalize;
   }
   .admin-dropdown > li > a {
     @apply block w-full h-full py-3;
   }
   .admin-dropdown > li.active {
-    @apply bg-primary bg-slate-400;
+    @apply bg-primary-light;
   }
   .icon-dropdown {
     @apply w-4 h-4 inline-block align-text-top;

--- a/src/header.ce.vue
+++ b/src/header.ce.vue
@@ -73,7 +73,7 @@ onMounted(() => {
       <div class="flex">
         <a
           href="/"
-          class="flex justify-center items-center px-8 bg-primary rounded-r-lg py-2"
+          class="flex justify-center items-center px-8 rounded-r-lg py-2"
         >
           <img
             v-if="props.logoUrl"
@@ -247,11 +247,7 @@ onMounted(() => {
       </div>
 
       <div
-        :class="[
-          { 'opacity-100 border-b-2': state.mobileMenuOpen },
-          { 'opacity-0 border-b-0': !state.mobileMenuOpen },
-          'absolute z-[1000] bg-white w-full duration-300 transition-opacity ease-in-out',
-        ]"
+        class="absolute z-[1000] bg-white w-full duration-300 transition-opacity ease-in-out"
       >
         <nav class="flex flex-col font-semibold" v-if="state.mobileMenuOpen">
           <a class="nav-item-mobile" href="/datahub/">{{ t('catalogue') }}</a>
@@ -282,31 +278,31 @@ onMounted(() => {
 
 @layer components {
   .nav-item-mobile {
-    @apply text-xl block text-center py-3 mx-2 w-full border-b border-b-secondary first-letter:capitalize;
+    @apply text-xl block text-center py-3 w-full border-b border-b-slate-300 first-letter:capitalize;
   }
   .nav-item {
     @apply relative text-lg w-fit block after:hover:scale-x-[82%] px-2 mx-2 hover:text-black first-letter:capitalize;
   }
   .nav-item:after {
-    @apply block content-[''] absolute h-[3px] bg-gradient-to-r from-primary to-secondary w-full scale-x-0  transition duration-300 origin-left;
+    @apply block content-[''] absolute h-[3px] bg-gradient-to-r from-primary to-slate-300 w-full scale-x-0  transition duration-300 origin-left;
   }
   .nav-item.active {
     @apply after:scale-x-[82%] after:bg-primary after:bg-none text-gray-900;
   }
   .btn {
-    @apply px-4 py-2 mx-2 text-slate-100 bg-primary rounded hover:bg-primary hover:bg-opacity-70 transition-colors first-letter:capitalize;
+    @apply px-4 py-2 mx-2 text-slate-100 bg-primary rounded hover:bg-slate-700 transition-colors first-letter:capitalize;
   }
   .link-btn {
-    @apply text-primary text-opacity-60 hover:text-primary hover:underline underline-offset-8 decoration-2 decoration-primary flex flex-col items-center;
+    @apply text-primary hover:text-slate-700 hover:underline underline-offset-8 decoration-2 decoration-slate-700 flex flex-col items-center;
   }
   .admin-dropdown > li {
-    @apply block text-center hover:bg-primary hover:bg-opacity-10 text-gray-700 hover:text-black capitalize;
+    @apply block text-center hover:bg-primary hover:bg-slate-300 text-gray-700 hover:text-black capitalize;
   }
   .admin-dropdown > li > a {
     @apply block w-full h-full py-3;
   }
   .admin-dropdown > li.active {
-    @apply bg-primary bg-opacity-20;
+    @apply bg-primary bg-slate-400;
   }
   .icon-dropdown {
     @apply w-4 h-4 inline-block align-text-top;

--- a/src/header.ce.vue
+++ b/src/header.ce.vue
@@ -68,7 +68,7 @@ onMounted(() => {
       v-bind:style="props.style"
     ></iframe>
   </div>
-  <header v-else class="host h-full text-base" v-bind:style="props.style">
+  <header v-else class="host h-[80px] text-base" v-bind:style="props.style">
     <div class="justify-between text-slate-600 sm:flex hidden h-full bg-white">
       <div class="flex">
         <a

--- a/src/header.ce.vue
+++ b/src/header.ce.vue
@@ -173,8 +173,8 @@ onMounted(() => {
         </nav>
       </div>
       <div></div>
-      <div class="flex justify-center items-center">
-        <div v-if="!isAnonymous" class="flex gap-4 items-baseline mx-6">
+      <div class="flex justify-center items-center mx-6">
+        <div v-if="!isAnonymous" class="flex gap-4 items-baseline">
           <a
             class="link-btn"
             href="/console/account/userdetails"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,8 +4,8 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: '#85127e',
-        secondary: '#1b1f3b',
+        primary: 'var(--primary)',
+        secondary: 'var(--secondary)',
       },
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,8 +4,10 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: 'var(--primary)',
-        secondary: 'var(--secondary)',
+        primary: 'var(--georchestra-primary)',
+        secondary: 'var(--georchestra-secondary)',
+        primary_light: 'var(--georchestra-primary-light)',
+        secondary_light: 'var(--georchestra-secondary-light)',
       },
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,8 +6,8 @@ module.exports = {
       colors: {
         primary: 'var(--georchestra-primary)',
         secondary: 'var(--georchestra-secondary)',
-        primary_light: 'var(--georchestra-primary-light)',
-        secondary_light: 'var(--georchestra-secondary-light)',
+        'primary-light': 'var(--georchestra-primary-light)',
+        'secondary-light': 'var(--georchestra-secondary-light)',
       },
     },
   },


### PR DESCRIPTION
# Header colors

## How to

Add `stylesheet` attribute to `geor-header` tag. E.g :
```html
<geor-header stylesheet="my-stylesheet.css"></geor-header>
```

## Colors available

Allow header to be themable with colors.

4 colors are now editable :

- `--georchestra-primary` default `#85127e` 
- `--georchestra-secondary` default `#1b1f3b` 
- `--georchestra-primary-light` default `rgba(133, 18, 126, 0.3)` 
- `--georchestra-secondary-light` default `rgba(27, 31, 59, 0.3)` 

### Example 

```css 
header {
  --georchestra-primary: #85127e;
  --georchestra-secondary: #1b1f3b;
  --georchestra-primary-light: rgba(133, 18, 126, 0.3);
  --georchestra-secondary-light: rgba(27, 31, 59, 0.3);
}
```

## More customization 

As we import a css file, we can customize more than colors. May need !important to override values.