### PR TITLE
Use first and lastname and avoid console error

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -16,6 +16,8 @@ interface WhoAmIResponse {
   GeorchestraUser: {
     roles: KNOWN_ROLES[]
     username: string
+    firstName: string
+    lastName: string
     ldapWarn: boolean
     ldapRemainingDays: string
   }
@@ -23,6 +25,8 @@ interface WhoAmIResponse {
 
 export interface User {
   username: string
+  firstname?: string
+  lastname?: string
   anonymous: boolean
   warned: boolean
   remainingDays: string
@@ -42,9 +46,20 @@ export async function getUserDetails(): Promise<User> {
     .then(response => response.json())
     .then((json: WhoAmIResponse) => {
       const user = json.GeorchestraUser
+      if (!user) {
+        return {
+          username: 'anonymousUser',
+          warned: false,
+          remainingDays: '0',
+          anonymous: true,
+          adminRoles: null,
+        }
+      }
       const roles = user.roles
       return {
         username: user.username,
+        firstname: user.firstName,
+        lastname: user.lastName,
         warned: user.ldapWarn,
         remainingDays: user.ldapRemainingDays,
         anonymous: roles.indexOf('ROLE_ANONYMOUS') > -1,

--- a/src/header.ce.vue
+++ b/src/header.ce.vue
@@ -192,11 +192,11 @@ onMounted(() => {
           <a
             class="link-btn"
             href="/console/account/userdetails"
-            :title="state.user?.username"
+            :title="state.user?.firstname + ' ' + state.user?.lastname"
           >
             <UserIcon class="font-bold text-3xl inline-block"></UserIcon>
             <span class="text-xs max-w-[120px] truncate">{{
-              state.user?.username
+              state.user?.firstname + ' ' + state.user?.lastname
             }}</span></a
           >
           <a class="link-btn" :href="logoutUrl"
@@ -254,7 +254,9 @@ onMounted(() => {
           <div v-if="!isAnonymous" class="flex gap-4 items-baseline">
             <a class="link-btn" href="/console/account/userdetails">
               <UserIcon class="font-bold text-3xl inline-block mr-4"></UserIcon>
-              <span>{{ state.user?.username }}</span></a
+              <span>{{
+                state.user?.firstname + ' ' + state.user?.lastname
+              }}</span></a
             >
             <a class="link-btn" :href="logoutUrl">logout</a>
           </div>


### PR DESCRIPTION
- Use first and lastname instead of username
- Return anon user if response from /whoami is null