### PR TITLE
Implement IMPORT role for datafeeder

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -11,6 +11,7 @@ type KNOWN_ROLES =
   | 'ROLE_GN_ADMIN'
   | 'ROLE_EMAILPROXY'
   | 'ROLE_ANONYMOUS'
+  | 'ROLE_IMPORT'
 
 interface WhoAmIResponse {
   GeorchestraUser: {
@@ -82,6 +83,7 @@ export function getAdminRoles(roles: KNOWN_ROLES[]): AdminRoles | null {
     console,
     catalog,
     viewer,
+    import: superUser || roles.indexOf('ROLE_IMPORT') > -1,
   }
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -40,6 +40,7 @@ export interface AdminRoles {
   console: boolean
   catalog: boolean
   viewer: boolean
+  import: boolean
 }
 
 export async function getUserDetails(): Promise<User> {

--- a/src/header.ce.vue
+++ b/src/header.ce.vue
@@ -121,7 +121,7 @@ onMounted(() => {
             >{{ t('services') }}</a
           >
           <a
-            v-if="!isAnonymous"
+            v-if="adminRoles?.import"
             class="nav-item"
             href="/import/"
             :class="{ active: props.activeApp === 'import' }"


### PR DESCRIPTION
This PR adds the import role to hide import tab.

⚠️ 🛑  This PR should not be merged until versioning of header's cdn is ready. As it will impact actuals configurations.

Depends on main PR : 
- https://github.com/georchestra/georchestra/pull/4190