### PR TITLE
add API menu to the default config

### DIFF
--- a/src/default-config.json
+++ b/src/default-config.json
@@ -43,6 +43,29 @@
       "hasRole": "ROLE_SUPERUSER,ROLE_IMPORT"
     },
     {
+      "type": "dropdown",
+      "label": "APIs",
+      "i18n": "APIs",
+      "items": [
+        {
+          "label": "OGC API Features",
+          "url": "/geoserver/ogc/features/v1 "
+        },
+        {
+          "label": "OGC API Records",
+          "url": "/ogc-api-records/"
+       },
+       {
+          "label": "Swagger Geonetwork",
+          "url": "/geonetwork/doc/api/index.html"
+       },
+       {
+          "label": "Swagger Superset",
+          "url": "/superset/swagger/v1"
+       }
+      ]
+    },
+    {
       "hasRole": "ROLE_SUPERUSER,ROLE_GN_EDITOR,ROLE_GN_ADMIN,ROLE_MAPSTORE_ADMIN",
       "type": "separator"
     },


### PR DESCRIPTION
because the platforms has a bunch of public APIs, and we do a pretty bad job at making them visible... i've put something similar in https://demo.georchestra.org/header-config.json

candidates for addition:
- geoserver REST API for users with ADMINISTRATOR role ?
- data-api ? with which prefix ?

the superset one is broken for now, cf apache/superset#33304

should that go to the default config or to the sample config ?