### PR TITLE
Fix dropdown width to match content and not parent

### DIFF
--- a/src/header.ce.vue
+++ b/src/header.ce.vue
@@ -266,7 +266,7 @@ onMounted(() => {
                   ></ChevronDownIcon>
                 </button>
                 <ul
-                  class="absolute hidden group-hover:block border rounded w-full dropdown z-[1002] bg-white"
+                  class="absolute hidden group-hover:flex flex-col w-max border rounded dropdown z-[1002] bg-white"
                 >
                   <template
                     v-for="(subitem, subindex) in (item as Dropdown).items"
@@ -281,6 +281,7 @@ onMounted(() => {
                         active: (subitem as Link).activeAppUrl == state.activeAppUrl,
                         disabled: (subitem as Link).disabled
                       }"
+                      class="px-4"
                     >
                       <a
                         :href="replaceUrlsVariables(subitem.url)"


### PR DESCRIPTION
Instead of having dropdown taking hovered link width: 
<img width="338" height="254" alt="image" src="https://github.com/user-attachments/assets/91ce7268-5492-4980-88f2-3f06cf4560b2" />


We now take content size instead: 
<img width="338" height="254" alt="image" src="https://github.com/user-attachments/assets/9affbe61-56a4-4c6f-95e1-5878030b052e" />
