### PR TITLE
#49 - provide class and allow custom icon from URL

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -42,6 +42,35 @@ example `justify-between`).
 > See Tailwind's justify content utilities:
 > https://tailwindcss.com/docs/justify-content
 
+### Custom icon
+
+The NavItem component (link and dropdown) supports two ways to display an icon:
+
+- Using a URL with with iconUrl` param
+- using icon from css sheet (e.g iconoir) with icon param
+
+`iconUrl` will be use first if both are provided.
+
+Examples : 
+
+```
+iconUrl: "/icons/catalog.svg"
+icon: "icon": "iconoir-map"
+```
+
+
+### Custom class
+
+You can insert a custom class onto link and dropdown element via `customClass` param.
+
+Example : 
+
+```
+customClass: "custom-catalog-btn"
+```
+
+### Active tab matching 
+
 **Example:**
 
 ```json

--- a/src/config-interfaces.ts
+++ b/src/config-interfaces.ts
@@ -21,6 +21,10 @@ export interface Link extends AbstractBaseInterface {
   icon?: string
   //If the link is clickable
   disabled?: boolean
+  // custom css class to add on element
+  customClass?: string
+  // to use icon from url instead icon from lib
+  iconUrl: string
 }
 
 export interface Dropdown extends AbstractBaseInterface {
@@ -29,6 +33,12 @@ export interface Dropdown extends AbstractBaseInterface {
   i18n?: string
   //List of items to display in the dropdown
   items?: Array<Link>
+  // custom css class to add on element
+  customClass?: string
+  // to use icon from url instead icon from lib
+  iconUrl: string
+  //Icon to display next to the label
+  icon?: string
 }
 
 export interface Separator extends AbstractBaseInterface {}

--- a/src/ui/DropdownItem.vue
+++ b/src/ui/DropdownItem.vue
@@ -21,9 +21,28 @@ const props = defineProps<{
         class="lg:mr-2 md:mr-1 first-letter:capitalize"
         >{{ getItemSelectedTitle(props.item.items) }}</span
       >
-      <span v-else class="lg:mr-2 md:mr-1 first-letter:capitalize">{{
-        props.item.i18n ? t(props.item.i18n) : props.item.label
-      }}</span>
+      <span
+        v-else
+        :class="[
+          'flex items-center lg:mr-2 md:mr-1 first-letter:capitalize',
+          props.item.customClass,
+        ]"
+      >
+        <img
+          v-if="props.item.iconUrl"
+          :src="props.item.iconUrl"
+          alt=""
+          class="pr-1 block pb-[2px] subitem-icon"
+          style="width: 1rem; height: 1rem"
+        />
+        <i
+          v-else-if="props.item.icon"
+          :class="props.item.icon"
+          class="pr-1 block pb-[2px] subitem-icon"
+          style="font-size: 1rem"
+        ></i>
+        {{ props.item.i18n ? t(props.item.i18n) : props.item.label }}</span
+      >
       <ChevronDownIcon
         class="w-4 h-4 transition-transform duration-200 group-hover:rotate-180"
         stroke-width="4"
@@ -40,18 +59,27 @@ const props = defineProps<{
           <li
             v-if="checkCondition(subitem)"
             @click="state.activeAppUrl = (subitem as Link).activeAppUrl"
-            :class="{
-                        active: (subitem as Link).activeAppUrl == state.activeAppUrl,
-                        disabled: (subitem as Link).disabled
-                      }"
-            class="px-4 transition-colors duration-100 hover:bg-gray-50"
+            :class="[
+              'px-4 transition-colors duration-100 hover:bg-gray-50',
+              subitem.customClass,
+              {
+                active: (subitem as Link).activeAppUrl == state.activeAppUrl,
+                disabled: (subitem as Link).disabled
+              }]"
           >
             <a
               :href="replaceUrlsVariables(subitem.url)"
               class="capitalize !flex justify-start items-start"
             >
+              <img
+                v-if="subitem.iconUrl"
+                :src="subitem.iconUrl"
+                alt=""
+                class="pr-1 block pb-[2px] subitem-icon"
+                style="width: 1rem; height: 1rem"
+              />
               <i
-                v-if="subitem.icon"
+                v-else-if="subitem.icon"
                 :class="subitem.icon"
                 class="pr-1 block pb-[2px] subitem-icon"
                 style="font-size: 1rem"

--- a/src/ui/LinkItem.vue
+++ b/src/ui/LinkItem.vue
@@ -12,14 +12,26 @@ const props = defineProps<{
     :href="props.item.url"
     class="nav-item"
     @click="state.activeAppUrl = props.item.activeAppUrl"
-    :class="{
-      active: props.item.activeAppUrl == state.activeAppUrl,
-      disabled: props.item.disabled,
-    }"
+    :class="[
+      props.item.customClass,
+      {
+        active: props.item.activeAppUrl == state.activeAppUrl,
+        disabled: props.item.disabled,
+      },
+    ]"
   >
     <div class="flex items-center">
+      <!-- Icon from URL (highest priority) -->
+      <img
+        v-if="props.item.iconUrl"
+        :src="props.item.iconUrl"
+        alt=""
+        class="item-icon"
+        style="width: 0.9rem; height: 0.9rem"
+      />
+      <!-- Icon from CSS class (fallback if no iconUrl) -->
       <i
-        v-if="props.item.icon"
+        v-else-if="props.item.icon"
         :class="props.item.icon"
         class="item-icon"
         style="font-size: 0.9rem"


### PR DESCRIPTION
> ref #49 

### Description

This PR insert two param for Link and Dropdown menu elements :

- iconUrl : use URL to custom link icon
- customClass : use string to complet or add new class (useable by custom CSS file)

### How to test ?

Rplace this code into sample-config.json :

```
    {
      "label": "WMS/WFS",
      "i18n": "customi18n",
      "url": "/geoserver/web",
      "activeAppUrl": "includes:/geoserver",
      "icon": "iconoir-map"
    },
```
    
By this code (adapta svg path !) :
    
```
        {
      "label": "WMS/WFS",
      "i18n": "customi18n",
      "url": "/geoserver/web",
      "activeAppUrl": "includes:/geoserver",
      "iconUrl": "/public/custom.svg",
      "icon": "iconoir-map",
      "customClass": "custom-link"
    },
```
    
And insert this rule into georchestra.css,: 
    
```
.custom-link {
    color: red;
}
```

To test with a DropDown, use this two param in dropdown or dropdown items : 


```
    {
      "type": "dropdown",
      "label": "A dropdown",
      "customClass": "foo-class",
      "icon": "iconoir-globe",
      "items": [
        {
          "label": "Console",
          "i18n": "users",
          "url": "/console/manager/home",
          "activeAppUrl": "/console",
          "icon": "iconoir-globe",
          "customClass": "bar-class"
        },
        {
          "label": "Geonetwork",
          "i18n": "catalogue",
          "url": "/geonetwork/srv/:lang3/catalog.edit#/board",
          "activeAppUrl": "/geonetwork",
          "disabled": true,
          "iconUrl": "custom-file.svg"
        }]
    }
```

