### PR TITLE
Reserve header height before content is loaded and a target links

### DIFF
--- a/src/config-interfaces.ts
+++ b/src/config-interfaces.ts
@@ -25,6 +25,8 @@ export interface Link extends AbstractBaseInterface {
   customClass?: string
   // to use icon from url instead icon from lib
   iconUrl: string
+  //Target to open the link in (e.g. '_blank' to open in a new tab)
+  target?: string
 }
 
 export interface Dropdown extends AbstractBaseInterface {

--- a/src/header.ce.vue
+++ b/src/header.ce.vue
@@ -142,58 +142,45 @@ onMounted(() => {
     ></iframe>
   </div>
   <header
-    v-else-if="state.loaded"
+    v-else
     class="host h-[80px] text-base"
     :class="{ 'has-custom-stylesheet': state.config.stylesheet }"
     :style="`height:${props.height}px`"
   >
-    <link
-      rel="stylesheet"
-      :href="state.config.stylesheet"
-      v-if="state.config.stylesheet"
-      :nonce="props.customNonce"
-    />
-    <link
-      rel="stylesheet"
-      :href="state.config.iconsUrl"
-      v-if="state.config.iconsUrl"
-      :nonce="props.customNonce"
-    />
-    <div
-      class="justify-between text-slate-600 lg:flex hidden h-full bg-white lg:text-sm"
-    >
-      <div class="flex header-left flex-1 min-w-0">
-        <Logo :logoUrl="props.logoUrl || state.config.logoUrl" />
-        <nav
-          :class="[
-            'flex items-center font-semibold header-nav grow',
-            navigation.class || 'justify-start',
-          ]"
-        >
-          <Menu :items="navigation?.menus ?? []" />
-
-          <span class="text-gray-400 text-xs" v-if="isWarned">
-            <a href="/console/account/changePassword">
-              {{ t('remaining_days_msg_part1') }} {{ remainingDays }}
-              {{ t('remaining_days_msg_part2') }}
-              {{ t('remaining_days_msg_part3') }}</a
-            ></span
-          >
-        </nav>
-      </div>
-      <AccountItem
-        :is-anonymous="isAnonymous"
-        :login-url="loginUrl"
-        :logout-url="logoutUrl"
+    <template v-if="state.loaded">
+      <link
+        rel="stylesheet"
+        :href="state.config.stylesheet"
+        v-if="state.config.stylesheet"
+        :nonce="props.customNonce"
       />
-    </div>
-    <div class="flex-col lg:hidden w-full h-full">
+      <link
+        rel="stylesheet"
+        :href="state.config.iconsUrl"
+        v-if="state.config.iconsUrl"
+        :nonce="props.customNonce"
+      />
       <div
-        class="h-full flex items-center justify-between px-4 py-1 shrink-0 w-full bg-primary/10"
+        class="justify-between text-slate-600 lg:flex hidden h-full bg-white lg:text-sm"
       >
-        <div class="h-full flex">
-          <BurgerIcon class="mr-3" />
+        <div class="flex header-left flex-1 min-w-0">
           <Logo :logoUrl="props.logoUrl || state.config.logoUrl" />
+          <nav
+            :class="[
+              'flex items-center font-semibold header-nav grow',
+              navigation.class || 'justify-start',
+            ]"
+          >
+            <Menu :items="navigation?.menus ?? []" />
+
+            <span class="text-gray-400 text-xs" v-if="isWarned">
+              <a href="/console/account/changePassword">
+                {{ t('remaining_days_msg_part1') }} {{ remainingDays }}
+                {{ t('remaining_days_msg_part2') }}
+                {{ t('remaining_days_msg_part3') }}</a
+              ></span
+            >
+          </nav>
         </div>
         <AccountItem
           :is-anonymous="isAnonymous"
@@ -201,15 +188,30 @@ onMounted(() => {
           :logout-url="logoutUrl"
         />
       </div>
+      <div class="flex-col lg:hidden w-full h-full">
+        <div
+          class="h-full flex items-center justify-between px-4 py-1 shrink-0 w-full bg-primary/10"
+        >
+          <div class="h-full flex">
+            <BurgerIcon class="mr-3" />
+            <Logo :logoUrl="props.logoUrl || state.config.logoUrl" />
+          </div>
+          <AccountItem
+            :is-anonymous="isAnonymous"
+            :login-url="loginUrl"
+            :logout-url="logoutUrl"
+          />
+        </div>
 
-      <div
-        class="absolute z-[1000] bg-white w-full duration-100 transition-opacity ease-in-out"
-      >
-        <nav class="flex flex-col font-semibold" v-if="state.mobileMenuOpen">
-          <Menu :items="navigation?.menus ?? []" />
-        </nav>
+        <div
+          class="absolute z-[1000] bg-white w-full duration-100 transition-opacity ease-in-out"
+        >
+          <nav class="flex flex-col font-semibold" v-if="state.mobileMenuOpen">
+            <Menu :items="navigation?.menus ?? []" />
+          </nav>
+        </div>
       </div>
-    </div>
+    </template>
   </header>
 </template>
 
@@ -217,6 +219,10 @@ onMounted(() => {
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:host {
+  display: block;
+}
 
 .host {
   -webkit-text-size-adjust: 100%;

--- a/src/ui/DropdownItem.vue
+++ b/src/ui/DropdownItem.vue
@@ -57,6 +57,10 @@ const props = defineProps<{
           >
             <a
               :href="replaceUrlsVariables(subitem.url)"
+              :target="subitem.target"
+              :rel="
+                subitem.target === '_blank' ? 'noopener noreferrer' : undefined
+              "
               class="capitalize !flex justify-start items-start"
             >
               <img

--- a/src/ui/LinkItem.vue
+++ b/src/ui/LinkItem.vue
@@ -10,6 +10,8 @@ const props = defineProps<{
 <template>
   <a
     :href="props.item.url"
+    :target="props.item.target"
+    :rel="props.item.target === '_blank' ? 'noopener noreferrer' : undefined"
     class="nav-item"
     @click="state.activeAppLink = props.item"
     :class="[

--- a/src/ui/Menu.vue
+++ b/src/ui/Menu.vue
@@ -56,6 +56,10 @@ function toggleDropdown(index: number) {
         <a
           v-if="!item.type"
           :href="replaceUrlsVariables(asLink(item).url)"
+          :target="asLink(item).target"
+          :rel="
+            asLink(item).target === '_blank' ? 'noopener noreferrer' : undefined
+          "
           class="nav-item-mobile"
           :class="{
             active: asLink(item) === state.activeAppLink,
@@ -90,6 +94,8 @@ function toggleDropdown(index: number) {
               v-for="sub in asDropdown(item).items"
               :key="sub.label"
               :href="replaceUrlsVariables(sub.url)"
+              :target="sub.target"
+              :rel="sub.target === '_blank' ? 'noopener noreferrer' : undefined"
               class="block py-3 px-10 text-sm border-b last:border-0 text-center"
               :class="{
                 active: sub === state.activeAppLink,


### PR DESCRIPTION
Two commits here: 

- One is to add target to links in order to be able to open links in another tab or else.

- Second is to load height of the header before loading config file or getUrseDetails, improving loading/smothness sensation of integration of the new header